### PR TITLE
URL Cleanup

### DIFF
--- a/gemfire-client-sts-template/pom.xml
+++ b/gemfire-client-sts-template/pom.xml
@@ -60,7 +60,7 @@
 		<repository>
 		<id>repo.springsource.org.plugins.release</id>
 			<name>Spring Framework Dependencies Repository</name>
-			<url>http://repo.springsource.org/plugins-release</url>
+			<url>https://repo.springsource.org/plugins-release</url>
 		</repository>
 	</repositories>
 

--- a/gemfire-server-sts-template/pom.xml
+++ b/gemfire-server-sts-template/pom.xml
@@ -60,7 +60,7 @@
 		<repository>
 		<id>repo.springsource.org.plugins.release</id>
 			<name>Spring Framework Dependencies Repository</name>
-			<url>http://repo.springsource.org/plugins-release</url>
+			<url>https://repo.springsource.org/plugins-release</url>
 		</repository>
 	</repositories>
 

--- a/gemfire-server-war-sts-template/pom.xml
+++ b/gemfire-server-war-sts-template/pom.xml
@@ -68,7 +68,7 @@
 		<repository>
 		<id>repo.springsource.org.plugins.release</id>
 			<name>Spring Framework Dependencies Repository</name>
-			<url>http://repo.springsource.org/plugins-release</url>
+			<url>https://repo.springsource.org/plugins-release</url>
 		</repository>
 	</repositories>
 

--- a/gemfire-standalone-sts-template/pom.xml
+++ b/gemfire-standalone-sts-template/pom.xml
@@ -60,7 +60,7 @@
 		<repository>
 		<id>repo.springsource.org.plugins.release</id>
 			<name>Spring Framework Dependencies Repository</name>
-			<url>http://repo.springsource.org/plugins-release</url>
+			<url>https://repo.springsource.org/plugins-release</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://repo.springsource.org/plugins-release migrated to:  
  https://repo.springsource.org/plugins-release ([https](https://repo.springsource.org/plugins-release) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance